### PR TITLE
Allow access to the raw socket object from 'request' event

### DIFF
--- a/dist/fxos-web-server.js
+++ b/dist/fxos-web-server.js
@@ -536,7 +536,8 @@ HTTPServer.prototype.start = function() {
 
       this.dispatchEvent('request', {
         request: request,
-        response: response
+        response: response,
+        socket: connectEvent
       });
     });
 

--- a/example/directory/lib/fxos-web-server.js
+++ b/example/directory/lib/fxos-web-server.js
@@ -536,7 +536,8 @@ HTTPServer.prototype.start = function() {
 
       this.dispatchEvent('request', {
         request: request,
-        response: response
+        response: response,
+        socket: connectEvent
       });
     });
 

--- a/example/p2p/lib/fxos-web-server.js
+++ b/example/p2p/lib/fxos-web-server.js
@@ -536,7 +536,8 @@ HTTPServer.prototype.start = function() {
 
       this.dispatchEvent('request', {
         request: request,
-        response: response
+        response: response,
+        socket: connectEvent
       });
     });
 

--- a/example/simple/lib/fxos-web-server.js
+++ b/example/simple/lib/fxos-web-server.js
@@ -536,7 +536,8 @@ HTTPServer.prototype.start = function() {
 
       this.dispatchEvent('request', {
         request: request,
-        response: response
+        response: response,
+        socket: connectEvent
       });
     });
 

--- a/example/upload/lib/fxos-web-server.js
+++ b/example/upload/lib/fxos-web-server.js
@@ -536,7 +536,8 @@ HTTPServer.prototype.start = function() {
 
       this.dispatchEvent('request', {
         request: request,
-        response: response
+        response: response,
+        socket: connectEvent
       });
     });
 

--- a/src/http-server.js
+++ b/src/http-server.js
@@ -52,7 +52,8 @@ HTTPServer.prototype.start = function() {
 
       this.dispatchEvent('request', {
         request: request,
-        response: response
+        response: response,
+        socket: connectEvent
       });
     });
 


### PR DESCRIPTION
Handy to check where the request is coming from, or do other more complicated things using the TCP socket API.
