### PR TITLE
Allow for the package to be used with node's require()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,38 @@
-Firefox OS Web Server
-=====================
+# Firefox OS Web Server
 
-A basic HTTP server for Firefox OS
+> A basic HTTP server for Firefox OS, written in JavaScript!
+
+## Installing it
+
+```bash
+npm install git+https://github.com/justindarc/fxos-web-server.git
+```
+
+## Using it
+
+```javascript
+
+// Require the server code
+var HTTPServer = require('fxos-web-server');
+
+// Make an instance listening in port 80
+var server = new HTTPServer(80);
+
+// Listen to request events
+server.addEventListener('request', function(evt) {
+
+	// To make things simple, we'll respond by displaying the request path
+	var responseText = evt.request.path;
+	var response = evt.response;
+	response.send(responseText);
+
+});
+
+// Finally start the server
+server.start();
+
+// (you can stop it afterwards with server.stop())
+
+```
+
+You can also have a look at the examples in the `example` folder.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "fxos-web-server",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "homepage": "https://github.com/justindarc/fxos-web-server",
   "license": "MIT",
-  "main": "dist/fxos-web-server.js",
+  "main": "src/http-server.js",
   "directories": {
     "example": "examples",
     "test": "test"


### PR DESCRIPTION
Pointing to dist/fxos-web-server.js as the main package.json entry didn't work as many things were missing and browserify was very confused.

My version works as you would expect with a node package, allowing you to require(/path/to/fxoswebserver) or npm install with a git+ protocol pointing to github and everything works without having to copy a file into your code base.

This will also enable you to publish to npm and make people happy :)
